### PR TITLE
Expose run_command

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -222,14 +222,14 @@ impl IMAPStream {
 		self.run_command_and_check_ok(&format!("COPY {} {}", sequence_set, mailbox_name).to_string())
 	}
 
-	fn run_command_and_check_ok(&mut self, command: &str) -> Result<()> {
+	pub fn run_command_and_check_ok(&mut self, command: &str) -> Result<()> {
 		match self.run_command(command) {
 			Ok(lines) => IMAPStream::parse_response_ok(lines),
 			Err(e) => Err(e)
 		}
 	}
 
-	fn run_command(&mut self, untagged_command: &str) -> Result<Vec<String>> {
+	pub fn run_command(&mut self, untagged_command: &str) -> Result<Vec<String>> {
 		let command = self.create_command(untagged_command.to_string());
 
 		match self.write_str(&*command) {


### PR DESCRIPTION
Given that the IMAP protocol is far from being fully covered by the rust-imap package
and that there might be extensions in the wild that one might want to utilize
and that there might be cludges to workaround,
I think it's only wise to expose the `run_command` methods, allowing the user of the library to run IMAP commands against the server.

It also makes it easier to live-test various IMAP commands before including them in the library.
