### PR TITLE
Escape password according to RFC3501

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -12,6 +12,12 @@ const INITIAL_TAG: u32 = 0;
 const CR: u8 = 0x0d;
 const LF: u8 = 0x0a;
 
+macro_rules! quote {
+	($x: expr) => (
+		format!("\"{}\"", $x.replace("\\", "\\\\").replace("\"", "\\\""))
+		)
+}
+
 /// Stream to interface with the IMAP server. This interface is only for the command stream.
 pub struct Client<T> {
 	stream: T,
@@ -105,7 +111,7 @@ impl<T: Read+Write> Client<T> {
 
 	/// Log in to the IMAP server.
 	pub fn login(&mut self, username: & str, password: & str) -> Result<()> {
-		self.run_command_and_check_ok(&format!("LOGIN {} {}", username, password).to_string())
+		self.run_command_and_check_ok(&format!("LOGIN {} {}", username, quote!(password)).to_string())
 	}
 
 	/// Selects a mailbox
@@ -362,7 +368,7 @@ mod tests {
 		let response = b"a1 OK Logged in\r\n".to_vec();
 		let username = "username";
 		let password = "password";
-		let command = format!("a1 LOGIN {} {}\r\n", username, password);
+		let command = format!("a1 LOGIN {} {}\r\n", username, quote!(password));
 		let mock_stream = MockStream::new(response);
 		let mut client = Client::new(mock_stream);
 		client.login(username, password).unwrap();


### PR DESCRIPTION
According to [RFC3501](https://tools.ietf.org/html/rfc3501), string should be literal or quoted strings. I found a bug that didn't allow me to login with a password containing spaces, thus giving me an error of "Too many arguments" in the `LOGIN` request.
I've added a macro rule `quote!` to escape `"`, `\\` and quote passwords, in order to avoid such error.

If there is any problem with my PR, I'm open to suggestions :) 

EDIT: I think that that macro should be applied also to other methods, such as `create` and `delete` (see http://donsutherland.org/crib/imap), in order to avoid users to manually escape like this: `imap_socket.delete("\"three words test\"").unwrap();`.