### PR TITLE
update to openssl 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "imap"
 path = "src/lib.rs"
 
 [dependencies]
-openssl = "0.8"
+openssl = "0.9"
 regex = "0.2"
 
 [dev-dependencies]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,14 +1,14 @@
 extern crate imap;
 extern crate openssl;
 
-use openssl::ssl::{SslContext, SslMethod};
+use openssl::ssl::{SslConnectorBuilder, SslMethod};
 use imap::client::Client;
 
 // To connect to the gmail IMAP server with this you will need to allow unsecure apps access.
 // See: https://support.google.com/accounts/answer/6010255?hl=en
 // Look at the gmail_oauth2.rs example on how to connect to a gmail server securely.
 fn main() {
-	let mut imap_socket = Client::secure_connect(("imap.gmail.com", 993), SslContext::new(SslMethod::Sslv23).unwrap()).unwrap();
+	let mut imap_socket = Client::secure_connect(("imap.gmail.com", 993), "imap.gmail.com",SslConnectorBuilder::new(SslMethod::tls()).unwrap().build()).unwrap();
 
 	imap_socket.login("username", "password").unwrap();
 

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -2,7 +2,7 @@ extern crate imap;
 extern crate openssl;
 extern crate base64;
 
-use openssl::ssl::{SslContext, SslMethod};
+use openssl::ssl::{SslConnectorBuilder, SslMethod};
 use base64::{encode};
 use imap::client::Client;
 use imap::authenticator::Authenticator;
@@ -24,7 +24,7 @@ fn main() {
         user: String::from("sombody@gmail.com"),
         access_token: String::from("<access_token>")
     };
-    let mut imap_socket = Client::secure_connect(("imap.gmail.com", 993), SslContext::new(SslMethod::Sslv23).unwrap()).unwrap();
+    let mut imap_socket = Client::secure_connect(("imap.gmail.com", 993),"imap.gmail.com", SslConnectorBuilder::new(SslMethod::tls()).unwrap().build()).unwrap();
 
     imap_socket.authenticate("XOAUTH2", gmail_auth).unwrap();
 


### PR DESCRIPTION
This updates to the openssl crate 0.9 but introduces a api change.

Now you need to add a domain string to the `secure` and `secure_connect` methods to let openssl handle SNI ( Server Name Indication ) correctly.