### PR TITLE
Read bytes when fetching or uid_fetching.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/lib.rs"
 [dependencies]
 openssl = "0.9"
 regex = "0.2"
+lazy_static = "0.2"
 
 [dev-dependencies]
 base64 = "0.2"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -31,7 +31,7 @@ fn main() {
 	match imap_socket.fetch("2", "body[text]") {
 		Ok(lines) => {
 			for line in lines.iter() {
-				print!("{}", line);
+				print!("{}", String::from_utf8(line.1.clone()).unwrap());
 			}
 		},
 		Err(e) => println!("Error Fetching email 2: {}", e)

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -36,7 +36,7 @@ fn main() {
     match imap_socket.fetch("2", "body[text]") {
         Ok(lines) => {
             for line in lines.iter() {
-                print!("{}", line);
+                print!("{}", String::from_utf8(line.1.clone()).unwrap());
             }
         },
         Err(e) => println!("Error Fetching email 2: {}", e)

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,11 +2,12 @@ use std::net::{TcpStream, ToSocketAddrs};
 use openssl::ssl::{SslConnector, SslStream};
 use std::io::{self, Read, Write};
 use std::time::Duration;
+use regex::Regex;
 
 use super::mailbox::Mailbox;
 use super::authenticator::Authenticator;
 use super::parse::{parse_response_ok, parse_capability, parse_select_or_examine, parse_response, parse_authenticate_response};
-use super::error::{Error, Result};
+use super::error::{Error, Result, ParseError};
 
 static TAG_PREFIX: &'static str = "a";
 const INITIAL_TAG: u32 = 0;
@@ -270,13 +271,48 @@ impl<T: Read+Write> Client<T> {
 		parse_select_or_examine(lines)
 	}
 
-	/// Fetch retreives data associated with a message in the mailbox.
-	pub fn fetch(&mut self, sequence_set: &str, query: &str) -> Result<Vec<String>> {
-		self.run_command_and_read_response(&format!("FETCH {} {}", sequence_set, query).to_string())
+	fn fetch_result(&mut self, first_line: String) -> Result<(u32, Vec<u8>)> {
+		lazy_static! {
+			static ref START_RE: Regex = Regex::new("^\\* \\d+ FETCH \\D*(\\d+).*\\{(\\d+)\\}\r\n$").unwrap();
+		}
+		let (id, size) = if let Some(captures) = START_RE.captures(&first_line.clone()) {
+			(captures.get(1).unwrap().as_str().parse::<u32>().unwrap(),
+			captures.get(2).unwrap().as_str().parse::<usize>().unwrap())
+		} else {
+			return Err(Error::Parse(ParseError::FetchResponse(first_line)));
+		};
+		let mut data = Vec::new();
+		data.resize(size, 0);
+		try!(self.stream.read_exact(&mut data));
+		try!(self.readline()); // should be ")\r\n"
+		Ok((id, data))
 	}
 
-	pub fn uid_fetch(&mut self, uid_set: &str, query: &str) -> Result<Vec<String>> {
-		self.run_command_and_read_response(&format!("UID FETCH {} {}", uid_set, query).to_string())
+	fn fetch_common(&mut self, untagged_command: &str) -> Result<Vec<(u32, Vec<u8>)>> {
+		try!(self.run_command(untagged_command));
+		let mut found_tag_line = false;
+		let start_str = format!("{}{} ", TAG_PREFIX, self.tag);
+		let mut results = Vec::new();
+
+		while !found_tag_line {
+			let raw_data = try!(self.readline());
+			let line = String::from_utf8(raw_data).unwrap();
+			if (&*line).starts_with(&*start_str) {
+				found_tag_line = true;
+			} else {
+				results.push(try!(self.fetch_result(line)));
+			}
+		}
+		Ok(results)
+	}
+
+	/// Fetch retreives data associated with a message in the mailbox.
+	pub fn fetch(&mut self, sequence_set: &str, query: &str) -> Result<Vec<(u32, Vec<u8>)>> {
+		self.fetch_common(&format!("FETCH {} {}", sequence_set, query).to_string())
+	}
+
+	pub fn uid_fetch(&mut self, uid_set: &str, query: &str) -> Result<Vec<(u32, Vec<u8>)>> {
+		self.fetch_common(&format!("UID FETCH {} {}", uid_set, query).to_string())
 	}
 
 	/// Noop always succeeds, and it does nothing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 
 extern crate openssl;
 extern crate regex;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod authenticator;
 pub mod client;


### PR DESCRIPTION
This returns raw bytes for each result as well as the id.

This is a first version of this patch. It {c,sh}ould have more error checking.