### PR TITLE
Use docs.rs for documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ script:
 - |
   travis-cargo build &&
   travis-cargo test &&
-  travis-cargo bench &&
-  travis-cargo --only stable doc
+  travis-cargo bench
 after_success:
-- travis-cargo --only stable doc-upload
 - travis-cargo coveralls --exclude-pattern=/target --no-sudo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "imap"
 version = "0.4.0"
 authors = ["Matt McCoy <mattnenterprise@yahoo.com>"]
-documentation = "http://mattnenterprise.github.io/rust-imap"
+documentation = "https://docs.rs/imap/"
 repository = "https://github.com/mattnenterprise/rust-imap"
 homepage = "https://github.com/mattnenterprise/rust-imap"
 description = "IMAP client for Rust"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ IMAP Client for Rust
 [![Coverage Status](https://coveralls.io/repos/github/mattnenterprise/rust-imap/badge.svg?branch=master)](https://coveralls.io/github/mattnenterprise/rust-imap?branch=master)
 
 
-[Documentation](http://mattnenterprise.github.io/rust-imap)
+[Documentation](https://docs.rs/imap/)
 
 ### Usage
 Here is a basic example of using the client. See the examples directory for more examples.


### PR DESCRIPTION
This would also allow deleting the `gh-pages` branch (which is pretty large).
I'd also recommend adding `badges` and `categories` to make the crates.io page more useful (see [this](http://www.integer32.com/2017/01/20/categories-and-ci-badges.html)), but I'll leave that up to you.