### PR TITLE
Swap openssl for native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ name = "imap"
 path = "src/lib.rs"
 
 [dependencies]
-openssl = "0.9"
+native-tls = "0.1"
 regex = "0.2"
 bufstream = "0.1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,94 +1,71 @@
+# inspired by https://github.com/starkat99/appveyor-rust/blob/master/appveyor.yml
+
 environment:
-
-  global:
-    RUST_VERSION: stable
-    CRATE_NAME: imap
-    SSL_CERT_FILE: "C:\\OpenSSL\\cacert.pem"
-
   matrix:
 
-    # MinGW
-    - TARGET: i686-pc-windows-gnu
-      BITS: 32
-      MSYS2: 1
-      OPENSSL_VERSION: 1_1_0f
-    - TARGET: x86_64-pc-windows-gnu
-      BITS: 64
-      MSYS2: 1
-      OPENSSL_VERSION: 1_0_2L
+### MSVC Toolchains ###
 
-    # MSVC
-    - TARGET: i686-pc-windows-msvc
-      BITS: 32
-      OPENSSL_VERSION: 1_0_2L
-      OPENSSL_DIR: C:\OpenSSL
-    - TARGET: x86_64-pc-windows-msvc
-      BITS: 64
-      OPENSSL_VERSION: 1_1_0f
-      OPENSSL_DIR: C:\OpenSSL
+  # Stable 64-bit MSVC
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+  # Stable 32-bit MSVC
+    - channel: stable
+      target: i686-pc-windows-msvc
+  # Beta 64-bit MSVC
+    - channel: beta
+      target: x86_64-pc-windows-msvc
+  # Beta 32-bit MSVC
+    - channel: beta
+      target: i686-pc-windows-msvc
 
-    # MinGW beta
-    - TARGET: i686-pc-windows-gnu
-      BITS: 32
-      MSYS2: 1
-      OPENSSL_VERSION: 1_1_0f
-      RUST_VERSION: beta
-    - TARGET: x86_64-pc-windows-gnu
-      BITS: 64
-      MSYS2: 1
-      OPENSSL_VERSION: 1_0_2L
-      RUST_VERSION: beta
+### GNU Toolchains ###
 
-    # MSVC beta
-    - TARGET: i686-pc-windows-msvc
-      BITS: 32
-      MSYS2: 1
-      OPENSSL_VERSION: 1_0_2L
-      OPENSSL_DIR: C:\OpenSSL
-      RUST_VERSION: beta
-    - TARGET: x86_64-pc-windows-msvc
-      BITS: 64
-      OPENSSL_VERSION: 1_1_0f
-      OPENSSL_DIR: C:\OpenSSL
-      RUST_VERSION: beta
+  # Stable 64-bit GNU
+    - channel: stable
+      target: x86_64-pc-windows-gnu
+  # Stable 32-bit GNU
+    - channel: stable
+      target: i686-pc-windows-gnu
+  # Beta 64-bit GNU
+    - channel: beta
+      target: x86_64-pc-windows-gnu
+  # Beta 32-bit GNU
+    - channel: beta
+      target: i686-pc-windows-gnu
+
+### MinGW Toolchains ###
+
+  # Stable 64-bit MinGW
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+      MSYS_BITS: 64
+  # Stable 32-bit MinGW
+    - channel: stable
+      target: i686-pc-windows-msvc
+      MSYS_BITS: 32
+  # Beta 64-bit MinGW
+    - channel: beta
+      target: x86_64-pc-windows-msvc
+      MSYS_BITS: 64
+  # Beta 32-bit MinGW
+    - channel: beta
+      target: i686-pc-windows-msvc
+      MSYS_BITS: 32
 
 install:
-   # install OpenSSL
-  - ps: Start-FileDownload "http://slproweb.com/download/Win${env:BITS}OpenSSL-${env:OPENSSL_VERSION}.exe"
-  - Win%BITS%OpenSSL-%OPENSSL_VERSION%.exe /SILENT /VERYSILENT /SP- /DIR="C:\OpenSSL"
-  - appveyor DownloadFile https://curl.haxx.se/ca/cacert.pem -FileName C:\OpenSSL\cacert.pem
-
   # install Rust
-  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
-  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
-  - if defined MSYS2 set PATH=C:\msys64\mingw%BITS%\bin;%PATH%
-  - rustc -Vv
-  - cargo -V
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - rustup-init -yv --default-toolchain %channel% --default-host %target%
+  - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustc -vV
+  - cargo -vV
 
-  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
-  - rustup-init.exe -y --default-host %TARGET%
-  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
-  - if defined MSYS2 set PATH=C:\msys64\mingw%BITS%\bin;%PATH%
-  - rustc -V
-  - cargo -V
+# Building is done in the test phase, so we disable Appveyor's build phase.
+build: false
 
 test_script:
-  # we don't run the "test phase" when doing deploys
-  - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo build --target %TARGET% &&
-      cargo build --target %TARGET% --release &&
-      cargo test --target %TARGET% &&
-      cargo test --target %TARGET% --release
-    )
-
-cache:
-  - C:\Users\appveyor\.cargo\registry
-  - target
+  - cargo test
 
 notifications:
   - provider: Email
     on_build_success: false
-
-# Building is done in the test phase, so we disable Appveyor's build phase.
-build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,3 @@ build: false
 
 test_script:
   - cargo test
-
-notifications:
-  - provider: Email
-    on_build_success: false

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 extern crate imap;
-extern crate openssl;
+extern crate native_tls;
 
-use openssl::ssl::{SslConnectorBuilder, SslMethod};
+use native_tls::TlsConnector;
 use imap::client::Client;
 
 // To connect to the gmail IMAP server with this you will need to allow unsecure apps access.
@@ -11,7 +11,7 @@ fn main() {
     let domain = "imap.gmail.com";
     let port = 993;
     let socket_addr = (domain, port);
-    let ssl_connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap().build();
+    let ssl_connector = TlsConnector::builder().unwrap().build().unwrap();
     let mut imap_socket = Client::secure_connect(socket_addr, domain, ssl_connector).unwrap();
 
     imap_socket.login("username", "password").unwrap();

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -1,8 +1,8 @@
 extern crate base64;
 extern crate imap;
-extern crate openssl;
+extern crate native_tls;
 
-use openssl::ssl::{SslConnectorBuilder, SslMethod};
+use native_tls::TlsConnector;
 use base64::encode;
 use imap::client::Client;
 use imap::authenticator::Authenticator;
@@ -33,7 +33,7 @@ fn main() {
     let domain = "imap.gmail.com";
     let port = 993;
     let socket_addr = (domain, port);
-    let ssl_connector = SslConnectorBuilder::new(SslMethod::tls()).unwrap().build();
+    let ssl_connector = TlsConnector::builder().unwrap().build().unwrap();
     let mut imap_socket = Client::secure_connect(socket_addr, domain, ssl_connector).unwrap();
 
     imap_socket.authenticate("XOAUTH2", gmail_auth).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! imap is a IMAP client for Rust.
 
 extern crate bufstream;
-extern crate openssl;
+extern crate native_tls;
 extern crate regex;
 
 pub mod authenticator;


### PR DESCRIPTION
Following the request in #35, this replaces `openssl` with the more portable `native-tls` crate. It also seems to build faster. This does change the external interface to `imap`, since users now need to use `native_tls::TlsConnector` instead of `openssl::SslConnector`, but the change is pretty straightforward (see the changes to the example code).

We *could* add an optional feature called `openssl` which adds back `openssl` as a dependency + the various `impl`s, but I don't personally think that'd be worth the added complexity.

Fixes #35 and #24.