### PR TITLE
Switch from travis-cargo to cargo-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ addons:
 rust:
 - stable
 - beta
+- nightly
+
+matrix:
+  allow_failures:
+    - rust: nightly
 
 before_install:
 - |
@@ -29,4 +34,4 @@ script:
   cargo bench
 
 after_success:
-- cargo coveralls
+- "if [ $TRAVIS_RUST_VERSION = stable ]; then cargo coveralls; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,32 @@
 sudo: false
 language: rust
-cache: cargo
-# necessary for `travis-cargo coveralls --no-sudo`
+# Dependencies of kcov, used by coverage
 addons:
   apt:
     packages:
       - libcurl4-openssl-dev
       - libelf-dev
       - libdw-dev
+      - binutils-dev
+      - cmake
+    sources:
+      - kalakris-cmake
+
+
 rust:
-- 1.20.0
 - stable
 - beta
+
 before_install:
 - |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
+  cargo install cargo-travis &&
+  export PATH=$HOME/.cargo/bin:$PATH
+  
 script:
 - |
-  travis-cargo build &&
-  travis-cargo test &&
-  travis-cargo bench
+  cargo build &&
+  cargo test &&
+  cargo bench
+
 after_success:
-- travis-cargo coveralls --exclude-pattern=/target --no-sudo
+- cargo coveralls


### PR DESCRIPTION
travis-cargo no longer works with coveralls, and appears
to be unmaintained. This change use regular cargo to
build and test. It now uses cargo-travis to push test
results to coveralls.