### PR TITLE
Don’t panic on receiving data not encoded in UTF-8

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,7 @@ use super::mailbox::Mailbox;
 use super::authenticator::Authenticator;
 use super::parse::{parse_authenticate_response, parse_capability, parse_response,
                    parse_response_ok, parse_select_or_examine};
-use super::error::{Error, Result};
+use super::error::{Error, Result, ParseError};
 
 static TAG_PREFIX: &'static str = "a";
 const INITIAL_TAG: u32 = 0;
@@ -464,7 +464,7 @@ impl<T: Read + Write> Client<T> {
 
         while !found_tag_line {
             let raw_data = try!(self.readline());
-            let line = String::from_utf8(raw_data).unwrap();
+            let line = String::from_utf8(raw_data).map_err(|err| Error::Parse(ParseError::DataNotUtf8(err)))?;
             lines.push(line.clone());
             if (&*line).starts_with(&*start_str) {
                 found_tag_line = true;

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::result;
 use std::fmt;
 use std::error::Error as StdError;
 use std::net::TcpStream;
+use std::string::FromUtf8Error;
 
 use native_tls::HandshakeError as TlsHandshakeError;
 use native_tls::Error as TlsError;
@@ -85,6 +86,7 @@ impl StdError for Error {
             Error::Io(ref e) => Some(e),
             Error::Tls(ref e) => Some(e),
             Error::TlsHandshake(ref e) => Some(e),
+            Error::Parse(ParseError::DataNotUtf8(ref e)) => Some(e),
             _ => None,
         }
     }
@@ -98,6 +100,7 @@ pub enum ParseError {
     Capability(Vec<String>),
     // Authentication errors.
     Authentication(String),
+    DataNotUtf8(FromUtf8Error),
 }
 
 impl fmt::Display for ParseError {
@@ -114,6 +117,7 @@ impl StdError for ParseError {
             ParseError::StatusResponse(_) => "Unable to parse status response",
             ParseError::Capability(_) => "Unable to parse capability response",
             ParseError::Authentication(_) => "Unable to parse authentication response",
+            ParseError::DataNotUtf8(_) => "Unable to parse data as UTF-8 text",
         }
     }
 


### PR DESCRIPTION
Return a `Result` instead.