### PR TITLE
Make types eagerly implement common traits

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -16,6 +16,7 @@ const CR: u8 = 0x0d;
 const LF: u8 = 0x0a;
 
 /// Stream to interface with the IMAP server. This interface is only for the command stream.
+#[derive(Debug)]
 pub struct Client<T: Read + Write> {
     stream: BufStream<T>,
     tag: u32,
@@ -28,6 +29,7 @@ pub struct Client<T: Read + Write> {
 /// 2177](https://tools.ietf.org/html/rfc2177).
 ///
 /// As long a the handle is active, the mailbox cannot be otherwise accessed.
+#[derive(Debug)]
 pub struct IdleHandle<'a, T: Read + Write + 'a> {
     client: &'a mut Client<T>,
     keepalive: Duration,

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct Mailbox {
     pub flags: String,
     pub exists: u32,

--- a/src/mock_stream.rs
+++ b/src/mock_stream.rs
@@ -1,6 +1,7 @@
 use std::io::{Error, ErrorKind, Read, Result, Write};
 use std::cmp::min;
 
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub struct MockStream {
     read_buf: Vec<u8>,
     read_pos: usize,


### PR DESCRIPTION
See https://rust-lang-nursery.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits