### PR TITLE
Read bytes when fetching or uid_fetching. (workaround, do not merge!)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/lib.rs"
 native-tls = "0.1"
 regex = "0.2"
 bufstream = "0.1"
+lazy_static = "0.2"
 
 [dev-dependencies]
 base64 = "0.7"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -32,7 +32,7 @@ fn main() {
 
     match imap_socket.fetch("2", "body[text]") {
         Ok(lines) => for line in lines.iter() {
-            print!("{}", line);
+            print!("{}", String::from_utf8(line.1.clone()).unwrap());
         },
         Err(e) => println!("Error Fetching email 2: {}", e),
     };

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -45,7 +45,7 @@ fn main() {
 
     match imap_socket.fetch("2", "body[text]") {
         Ok(lines) => for line in lines.iter() {
-            print!("{}", line);
+            print!("{}", String::from_utf8(line.1.clone()).unwrap());
         },
         Err(e) => println!("Error Fetching email 2: {}", e),
     };

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,7 @@ use native_tls::{TlsConnector, TlsStream};
 use std::io::{self, Read, Write};
 use std::time::Duration;
 use bufstream::BufStream;
+use regex::Regex;
 
 use super::mailbox::Mailbox;
 use super::authenticator::Authenticator;
@@ -293,13 +294,48 @@ impl<T: Read + Write> Client<T> {
         parse_select_or_examine(lines)
     }
 
-    /// Fetch retreives data associated with a message in the mailbox.
-    pub fn fetch(&mut self, sequence_set: &str, query: &str) -> Result<Vec<String>> {
-        self.run_command_and_read_response(&format!("FETCH {} {}", sequence_set, query))
+    fn fetch_result(&mut self, first_line: String) -> Result<(u32, Vec<u8>)> {
+        lazy_static! {
+            static ref START_RE: Regex = Regex::new("^\\* \\d+ FETCH \\D*(\\d+).*\\{(\\d+)\\}\r\n$").unwrap();
+        }
+        let (id, size) = if let Some(captures) = START_RE.captures(&first_line.clone()) {
+            (captures.get(1).unwrap().as_str().parse::<u32>().unwrap(),
+            captures.get(2).unwrap().as_str().parse::<usize>().unwrap())
+        } else {
+            return Err(Error::Parse(ParseError::FetchResponse(first_line)));
+        };
+        let mut data = Vec::new();
+        data.resize(size, 0);
+        try!(self.stream.read_exact(&mut data));
+        try!(self.readline()); // should be ")\r\n"
+        Ok((id, data))
     }
 
-    pub fn uid_fetch(&mut self, uid_set: &str, query: &str) -> Result<Vec<String>> {
-        self.run_command_and_read_response(&format!("UID FETCH {} {}", uid_set, query))
+    fn fetch_common(&mut self, untagged_command: &str) -> Result<Vec<(u32, Vec<u8>)>> {
+        try!(self.run_command(untagged_command));
+        let mut found_tag_line = false;
+        let start_str = format!("{}{} ", TAG_PREFIX, self.tag);
+        let mut results = Vec::new();
+
+        while !found_tag_line {
+            let raw_data = try!(self.readline());
+            let line = String::from_utf8(raw_data).unwrap();
+            if (&*line).starts_with(&*start_str) {
+                found_tag_line = true;
+            } else {
+                results.push(try!(self.fetch_result(line)));
+            }
+        }
+        Ok(results)
+    }
+
+    /// Fetch retreives data associated with a message in the mailbox.
+    pub fn fetch(&mut self, sequence_set: &str, query: &str) -> Result<Vec<(u32, Vec<u8>)>> {
+        self.fetch_common(&format!("FETCH {} {}", sequence_set, query).to_string())
+    }
+
+    pub fn uid_fetch(&mut self, uid_set: &str, query: &str) -> Result<Vec<(u32, Vec<u8>)>> {
+        self.fetch_common(&format!("UID FETCH {} {}", uid_set, query).to_string())
     }
 
     /// Noop always succeeds, and it does nothing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 extern crate bufstream;
 extern crate native_tls;
 extern crate regex;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod authenticator;
 pub mod client;


### PR DESCRIPTION
This returns raw bytes for each result as well as the id. This was previously https://github.com/mattnenterprise/rust-imap/pull/33

This is a first version of this patch. It {c,sh}ould have more error checking.

I've checked this patch with DavMail, an IMAP proxy.

This patch was rejected before but until there is a better patch, this one is useful when one wants to have structured responses. I'm using this personally, so I'm just opening this patch so people that also need this functionality now can use it.

The real fix should come in https://github.com/mattnenterprise/rust-imap/issues/28