### PR TITLE
Validation of input strings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,9 @@ impl fmt::Display for Error {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
             Error::Tls(ref e) => fmt::Display::fmt(e, f),
             Error::TlsHandshake(ref e) => fmt::Display::fmt(e, f),
+            Error::BadResponse(ref data) => {
+                write!(f, "{}: {}", &String::from(self.description()), &data.join("\n"))
+            }
             ref e => f.write_str(e.description()),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
     ConnectionLost,
     // Error parsing a server response.
     Parse(ParseError),
+    // Error validating input data
+    Validate(ValidateError),
     // Error appending a mail
     Append,
 }
@@ -62,6 +64,7 @@ impl fmt::Display for Error {
             Error::Io(ref e) => fmt::Display::fmt(e, f),
             Error::Tls(ref e) => fmt::Display::fmt(e, f),
             Error::TlsHandshake(ref e) => fmt::Display::fmt(e, f),
+            Error::Validate(ref e) => fmt::Display::fmt(e, f),
             Error::BadResponse(ref data) => {
                 write!(f, "{}: {}", &String::from(self.description()), &data.join("\n"))
             }
@@ -77,6 +80,7 @@ impl StdError for Error {
             Error::Tls(ref e) => e.description(),
             Error::TlsHandshake(ref e) => e.description(),
             Error::Parse(ref e) => e.description(),
+            Error::Validate(ref e) => e.description(),
             Error::BadResponse(_) => "Bad Response",
             Error::NoResponse(_) => "No Response",
             Error::ConnectionLost => "Connection lost",
@@ -128,5 +132,26 @@ impl StdError for ParseError {
         match *self {
             _ => None,
         }
+    }
+}
+
+// Invalid character found. Expand as needed
+#[derive(Debug)]
+pub struct ValidateError(pub char);
+
+impl fmt::Display for ValidateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // print character in debug form because invalid ones are often whitespaces
+        write!(f, "{}: {:?}", self.description(), self.0)
+    }
+}
+
+impl StdError for ValidateError {
+    fn description(&self) -> &str {
+        "Invalid character in input"
+    }
+
+    fn cause(&self) -> Option<&StdError> {
+        None
     }
 }


### PR DESCRIPTION
These patches add 2 things: 
- rejecting input strings which contain `CR` or `LF` characters in what was previously (#56) handled just by `quote!`
- passing on the actual response inside `BadResponse`

This pull request is based on #56