### PR TITLE
client: extend APPEND to support optional flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ path = "src/lib.rs"
 native-tls = "0.1"
 regex = "0.2"
 bufstream = "0.1"
+chrono = "0.4"
 
 [dev-dependencies]
 base64 = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! imap is a IMAP client for Rust.
 
 extern crate bufstream;
+extern crate chrono;
 extern crate native_tls;
 extern crate regex;
 


### PR DESCRIPTION
According to [RFC3501][1], the APPEND command supports optional flags for
the datetime of the message receipt, and a set of flags to be applied to
the message. Implement this in imap-rust, using the same formatting as
the Python imaplib equivalent code.

[1]: https://tools.ietf.org/html/rfc3501#section-6.3.11

Fixes #60
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>