### PR TITLE
Borrow TlsConnector

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,7 +12,7 @@ fn main() {
     let port = 993;
     let socket_addr = (domain, port);
     let ssl_connector = TlsConnector::builder().unwrap().build().unwrap();
-    let mut imap_socket = Client::secure_connect(socket_addr, domain, ssl_connector).unwrap();
+    let mut imap_socket = Client::secure_connect(socket_addr, domain, &ssl_connector).unwrap();
 
     imap_socket.login("username", "password").unwrap();
 

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -34,7 +34,7 @@ fn main() {
     let port = 993;
     let socket_addr = (domain, port);
     let ssl_connector = TlsConnector::builder().unwrap().build().unwrap();
-    let mut imap_socket = Client::secure_connect(socket_addr, domain, ssl_connector).unwrap();
+    let mut imap_socket = Client::secure_connect(socket_addr, domain, &ssl_connector).unwrap();
 
     imap_socket.authenticate("XOAUTH2", gmail_auth).unwrap();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -213,11 +213,11 @@ impl Client<TcpStream> {
     pub fn secure(
         mut self,
         domain: &str,
-        ssl_connector: TlsConnector,
+        ssl_connector: &TlsConnector,
     ) -> Result<Client<TlsStream<TcpStream>>> {
         // TODO This needs to be tested
         self.run_command_and_check_ok("STARTTLS")?;
-        TlsConnector::connect(&ssl_connector, domain, try!(self.stream.into_inner()))
+        TlsConnector::connect(ssl_connector, domain, try!(self.stream.into_inner()))
             .map(Client::new)
             .map_err(Error::TlsHandshake)
     }
@@ -228,11 +228,11 @@ impl Client<TlsStream<TcpStream>> {
     pub fn secure_connect<A: ToSocketAddrs>(
         addr: A,
         domain: &str,
-        ssl_connector: TlsConnector,
+        ssl_connector: &TlsConnector,
     ) -> Result<Client<TlsStream<TcpStream>>> {
         match TcpStream::connect(addr) {
             Ok(stream) => {
-                let ssl_stream = match TlsConnector::connect(&ssl_connector, domain, stream) {
+                let ssl_stream = match TlsConnector::connect(ssl_connector, domain, stream) {
                     Ok(s) => s,
                     Err(e) => return Err(Error::TlsHandshake(e)),
                 };


### PR DESCRIPTION
TlsConnector is meant to be reusable and there is no reason to take
ownership over one.