### PR TITLE
Add passing back the email in [u8]

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -84,6 +84,7 @@ pub fn parse_fetches(lines: Vec<u8>) -> ZeroCopyResult<Vec<Fetch>> {
                 uid: None,
                 rfc822_header: None,
                 rfc822: None,
+                body: None,
             };
 
             for attr in attrs {
@@ -95,6 +96,7 @@ pub fn parse_fetches(lines: Vec<u8>) -> ZeroCopyResult<Vec<Fetch>> {
                     AttributeValue::Uid(uid) => fetch.uid = Some(uid),
                     AttributeValue::Rfc822(rfc) => fetch.rfc822 = rfc,
                     AttributeValue::Rfc822Header(rfc) => fetch.rfc822_header = rfc,
+                    AttributeValue::BodySection {section: _, index: _, data} => fetch.body = data,
                     _ => {}
                 }
             }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -84,6 +84,7 @@ pub fn parse_fetches(lines: Vec<u8>) -> ZeroCopyResult<Vec<Fetch>> {
                 uid: None,
                 rfc822_header: None,
                 rfc822: None,
+                email: None,
             };
 
             for attr in attrs {
@@ -95,6 +96,7 @@ pub fn parse_fetches(lines: Vec<u8>) -> ZeroCopyResult<Vec<Fetch>> {
                     AttributeValue::Uid(uid) => fetch.uid = Some(uid),
                     AttributeValue::Rfc822(rfc) => fetch.rfc822 = rfc,
                     AttributeValue::Rfc822Header(rfc) => fetch.rfc822_header = rfc,
+                    AttributeValue::BodySection {section, index, data} => fetch.email = data,
                     _ => {}
                 }
             }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -96,7 +96,7 @@ pub fn parse_fetches(lines: Vec<u8>) -> ZeroCopyResult<Vec<Fetch>> {
                     AttributeValue::Uid(uid) => fetch.uid = Some(uid),
                     AttributeValue::Rfc822(rfc) => fetch.rfc822 = rfc,
                     AttributeValue::Rfc822Header(rfc) => fetch.rfc822_header = rfc,
-                    AttributeValue::BodySection {section, index, data} => fetch.email = data,
+                    AttributeValue::BodySection {section: _, index: _, data} => fetch.email = data,
                     _ => {}
                 }
             }

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -7,6 +7,7 @@ pub struct Fetch {
     pub uid: Option<u32>,
     pub(crate) rfc822_header: Option<&'static [u8]>,
     pub(crate) rfc822: Option<&'static [u8]>,
+    pub email: Option<&'static [u8]>,
 }
 
 impl Fetch {

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -7,7 +7,7 @@ pub struct Fetch {
     pub uid: Option<u32>,
     pub(crate) rfc822_header: Option<&'static [u8]>,
     pub(crate) rfc822: Option<&'static [u8]>,
-    pub email: Option<&'static [u8]>,
+    pub(crate) email: Option<&'static [u8]>,
 }
 
 impl Fetch {
@@ -21,5 +21,9 @@ impl Fetch {
 
     pub fn rfc822<'a>(&'a self) -> Option<&'a [u8]> {
         self.rfc822
+    }
+
+    pub fn email<'a>(&'a self) -> Option<&'a [u8]> {
+        self.email
     }
 }

--- a/src/types/fetch.rs
+++ b/src/types/fetch.rs
@@ -7,6 +7,7 @@ pub struct Fetch {
     pub uid: Option<u32>,
     pub(crate) rfc822_header: Option<&'static [u8]>,
     pub(crate) rfc822: Option<&'static [u8]>,
+    pub(crate) body: Option<&'static [u8]>,
 }
 
 impl Fetch {
@@ -20,5 +21,9 @@ impl Fetch {
 
     pub fn rfc822<'a>(&'a self) -> Option<&'a [u8]> {
         self.rfc822
+    }
+
+    pub fn body<'a>(&'a self) -> Option<&'a [u8]> {
+        self.body
     }
 }


### PR DESCRIPTION
Pass back email in [u8] so it can be parsed by mailparse::parse_email
added email to fetch structure and used 
AttributeValue::BodySection {section: _, index: _, data} => fetch.email = data,
to get it