### PR TITLE
WIP: split `Client` into `UnauthenticatedClient` and `Client`

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -16,9 +16,9 @@ fn main() {
     let mut imap_session = match client.login("username", "password") {
         Ok(c) => c,
         Err((e, _unauth_client)) => {
-            println!("failed to login: {}", e);
+            eprintln!("failed to login: {}", e);
             return;
-        },
+        }
     };
 
     match imap_session.capabilities() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -431,12 +431,6 @@ impl<T: Read + Write> Client<T> {
         username: &str,
         password: &str
     ) -> ::std::result::Result<Session<T>, (Error, Client<T>)> {
-        // note that we need the explicit match blocks here for two reasons:
-        // 1. we need to convert the validate_str error type to our tuple of
-        //    (Error, Client)
-        // 2. we can't use `.map_err(|e| (e, self))` because that would capture self into the
-        //    closure. this way borowck sees that self is only bound in the error case where we
-        //    return anyways.
         let u = ok_or_unauth_client_err!(validate_str(username), self);
         let p = ok_or_unauth_client_err!(validate_str(password), self);
         ok_or_unauth_client_err!(self.run_command_and_check_ok(&format!("LOGIN {} {}", u, p)), self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,8 @@
 //! See the `examples/` directory for more examples.
 //!
 //! ```no_run
-//! # extern crate imap;
+//! extern crate imap;
 //! extern crate native_tls;
-//! # use imap::client::Client;
 //!
 //! // To connect to the gmail IMAP server with this you will need to allow unsecure apps access.
 //! // See: https://support.google.com/accounts/answer/6010255?hl=en
@@ -18,11 +17,17 @@
 //!     let port = 993;
 //!     let socket_addr = (domain, port);
 //!     let ssl_connector = native_tls::TlsConnector::builder().build().unwrap();
-//!     let mut imap_socket = Client::secure_connect(socket_addr, domain, &ssl_connector).unwrap();
+//!     let client = imap::client::secure_connect(socket_addr, domain, &ssl_connector).unwrap();
 //!
-//!     imap_socket.login("username", "password").unwrap();
+//!     let mut imap_session = match client.login("username", "password") {
+//!         Ok(c) => c,
+//!         Err((e, _unauth_client)) => {
+//!             eprintln!("failed to login: {}", e);
+//!             return;
+//!         }
+//!     };
 //!
-//!     match imap_socket.capabilities() {
+//!     match imap_session.capabilities() {
 //!         Ok(capabilities) => {
 //!             for capability in capabilities.iter() {
 //!                 println!("{}", capability);
@@ -31,14 +36,14 @@
 //!         Err(e) => println!("Error parsing capabilities: {}", e),
 //!     };
 //!
-//!     match imap_socket.select("INBOX") {
+//!     match imap_session.select("INBOX") {
 //!         Ok(mailbox) => {
 //!             println!("{}", mailbox);
 //!         }
 //!         Err(e) => println!("Error selecting INBOX: {}", e),
 //!     };
 //!
-//!     match imap_socket.fetch("2", "body[text]") {
+//!     match imap_session.fetch("2", "body[text]") {
 //!         Ok(messages) => {
 //!             for message in messages.iter() {
 //!                 print!("{:?}", message);
@@ -47,7 +52,7 @@
 //!         Err(e) => println!("Error Fetching email 2: {}", e),
 //!     };
 //!
-//!     imap_socket.logout().unwrap();
+//!     imap_session.logout().unwrap();
 //! }
 //! ```
 


### PR DESCRIPTION
a first attempt at the split between the unauthenticated (but connected) and the logged in state on the type level, as discussed in the comments of issue #80 . the only way to get a (logged in) `Client` instance is through successful calls to the `login`/`authenticate` methods. implementation-wise there's now a third type, `InnerClient`, which contains all lower-level functionality used by both `UnauthenticatedClient` and `Client` (to avoid duplicating the code or having weird cross-references between the `Client` and `UnauthenticatedClient` types.

as i'm mostly looking for feedback on the general direction of how i implemented the idea, there's not enough docs and i haven't ran `rustfmt` or `cargo test` yet etc. i'm especially hoping for feedback on

- do we want `connect`/`secure_connect` to stay in the `Client` type (but return an `UnauthenticatedClient`), so people can continue to write `Client::connect(..)`, or is it better to make the API break explicit here, as you have to deal with the return value of connect (the `UnauthenticatedClient`) differently now (i.e. don't provide a false sense of API continuity)?
- perhaps we might even want to re-add wrappers for the lower-level functions in `InnerClient` to the `Client` type, so we could reverse the changes to the (non-involved) `IdleHandle`. for now i only added wrappers for those that were marked `pub`.

i'm always happy to change things and re-submit. also i wasn't sure whether `UnauthenticatedClient`/`Client` or e.g. `Client`/`AuthenticatedClient` is the better naming; if people have thoughts on that i'm happy to hear those, too (in this first attempt i opted for the former, as this keeps more of the interface on the existing `Client` type).