### PR TITLE
Updated cargo references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ path = "src/lib.rs"
 
 [dependencies]
 native-tls = "0.2"
-regex = "0.2"
+regex = "1.0"
 bufstream = "0.1"
 imap-proto = "0.4.1"
 nom = "3.2.1"
 
 [dev-dependencies]
-base64 = "0.7"
+base64 = "0.9.2"


### PR DESCRIPTION
Updated the cargo references for:
- regex
  - 0.2 -> 1.0
- base64
  - 0.7 -> 0.9.2

Nom couldn't be upgraded (from 3.2.1 to 4.0) because it has some breaking changes. For the 3.x range, 3.2.1 is still the latest version. 

If anyone wants to pick that up, the migration guide is here: https://github.com/Geal/nom/blob/master/doc/upgrading_to_nom_4.md
