### PR TITLE
client: Add MOVE and UID MOVE support

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -563,12 +563,17 @@ impl <T: Read + Write> Session<T> {
         self.run_command_and_check_ok(&format!("UID COPY {} {}", uid_set, mailbox_name))
     }
 
-    /// Moves each message in the sequence into the destination mailbox.
-    pub fn imap_move(&mut self, sequence_set: &str, mailbox_name: &str) -> Result<()> {
+    /// Moves each message in the sequence into the destination mailbox. This function is
+    /// named `mv` instead of `move` due to it being a reserved keyword.
+    /// The MOVE command is defined in [RFC 6851 - "Internet Message Access Protocol (IMAP)
+    /// - MOVE Extension"](https://tools.ietf.org/html/rfc6851#section-3).
+    pub fn mv(&mut self, sequence_set: &str, mailbox_name: &str) -> Result<()> {
         self.run_command_and_check_ok(&format!("MOVE {} {}", sequence_set, validate_str(mailbox_name)?))
     }
 
     /// Moves each message in the uid set into the destination mailbox.
+    /// The UID MOVE command is defined in [RFC 6851 - "Internet Message Access Protocol (IMAP)
+    /// - MOVE Extension"](https://tools.ietf.org/html/rfc6851#section-3).
     pub fn uid_move(&mut self, uid_set: &str, mailbox_name: &str) -> Result<()> {
         self.run_command_and_check_ok(&format!(
             "UID MOVE {} {}",

--- a/src/client.rs
+++ b/src/client.rs
@@ -574,7 +574,7 @@ impl <T: Read + Write> Session<T> {
     /// Moves each message in the uid set into the destination mailbox.
     /// The UID MOVE command is defined in [RFC 6851 - "Internet Message Access Protocol (IMAP)
     /// - MOVE Extension"](https://tools.ietf.org/html/rfc6851#section-3).
-    pub fn uid_move(&mut self, uid_set: &str, mailbox_name: &str) -> Result<()> {
+    pub fn uid_mv(&mut self, uid_set: &str, mailbox_name: &str) -> Result<()> {
         self.run_command_and_check_ok(&format!(
             "UID MOVE {} {}",
             uid_set,
@@ -1210,7 +1210,7 @@ mod tests {
     }
 
     #[test]
-    fn uid_move() {
+    fn uid_mv() {
         let response = b"* OK [COPYUID 1511554416 142,399 41:42] Moved UIDs.\r\n\
             * 2 EXPUNGE\r\n\
             * 1 EXPUNGE\r\n\
@@ -1219,7 +1219,7 @@ mod tests {
         let command = format!("a1 UID MOVE 41:42 {}\r\n", quote!(mailbox_name));
         let mock_stream = MockStream::new(response);
         let mut session = mock_session!(mock_stream);
-        session.uid_move("41:42", mailbox_name).unwrap();
+        session.uid_mv("41:42", mailbox_name).unwrap();
         assert!(
             session.stream.get_ref().written_buf == command.as_bytes().to_vec(),
             "Invalid uid move command"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1193,7 +1193,7 @@ mod tests {
     }
 
     #[test]
-    fn imap_move() {
+    fn mv() {
         let response = b"* OK [COPYUID 1511554416 142,399 41:42] Moved UIDs.\r\n\
             * 2 EXPUNGE\r\n\
             * 1 EXPUNGE\r\n\
@@ -1202,7 +1202,7 @@ mod tests {
         let command = format!("a1 MOVE 1:2 {}\r\n", quote!(mailbox_name));
         let mock_stream = MockStream::new(response);
         let mut session = mock_session!(mock_stream);
-        session.imap_move("1:2", mailbox_name).unwrap();
+        session.mv("1:2", mailbox_name).unwrap();
         assert!(
             session.stream.get_ref().written_buf == command.as_bytes().to_vec(),
             "Invalid move command"


### PR DESCRIPTION
This implements the MOVE and UID MOVE commands as defined in the "Internet Message Access Protocol (IMAP) - MOVE Extension" [RFC6851](https://tools.ietf.org/html/rfc6851#section-3).