### PR TITLE
imap::client::Client::authenticate: Base64 encode the result of the Authenticator

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,4 @@
+extern crate base64;
 use bufstream::BufStream;
 use native_tls::{TlsConnector, TlsStream};
 use nom;
@@ -934,6 +935,28 @@ mod tests {
         assert!(
             command2 == expected_command2,
             "expected command doesn't equal actual command"
+        );
+    }
+
+    #[test]
+    fn authenticate() {
+        let response = b"+\r\n\
+                         a1 OK Logged in\r\n".to_vec();
+        let command =  "a1 AUTHENTICATE PLAIN\r\n\
+                        Zm9v\r\n";
+        let mock_stream = MockStream::new(response);
+        let client = Client::new(mock_stream);
+        enum Authenticate { Auth };
+        impl Authenticator for Authenticate {
+            fn process(&self, _: String) -> String {
+                "foo".to_string()
+            }
+        }
+        let auth = Authenticate::Auth;
+        let session = client.authenticate("PLAIN", auth).unwrap();
+        assert!(
+            session.stream.get_ref().written_buf == command.as_bytes().to_vec(),
+            "Invalid authenticate command"
         );
     }
 


### PR DESCRIPTION
Fixes issue #95.

Please bear with me, I'm only beginning Rust.

I see two issues with this one-liner:

1. it is _not_ backward compatible. What's the rules for this?
2. as `Authenticator::process` returns a `String`, it is not possible to submit arbitrary binary data. For fixing this `process` would have to return a `Vec<u8>`. What do you think?
