### PR TITLE
imap::client::Client::authenticate: Base64 encode the result of the A…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,4 @@ regex = "1.0"
 bufstream = "0.1"
 imap-proto = "0.6"
 nom = "4.0"
-
-[dev-dependencies]
 base64 = "0.10"

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -2,7 +2,6 @@ extern crate base64;
 extern crate imap;
 extern crate native_tls;
 
-use base64::encode;
 use imap::authenticator::Authenticator;
 use native_tls::TlsConnector;
 
@@ -12,13 +11,12 @@ struct GmailOAuth2 {
 }
 
 impl Authenticator for GmailOAuth2 {
+    type Response = String;
     #[allow(unused_variables)]
-    fn process(&self, data: String) -> String {
-        encode(
-            format!(
-                "user={}\x01auth=Bearer {}\x01\x01",
-                self.user, self.access_token
-            ).as_bytes(),
+    fn process(&self, data: String) -> Self::Response {
+        format!(
+            "user={}\x01auth=Bearer {}\x01\x01",
+            self.user, self.access_token
         )
     }
 }

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -13,7 +13,7 @@ struct GmailOAuth2 {
 impl Authenticator for GmailOAuth2 {
     type Response = String;
     #[allow(unused_variables)]
-    fn process(&self, data: String) -> Self::Response {
+    fn process(&self, data: Vec<u8>) -> Self::Response {
         format!(
             "user={}\x01auth=Bearer {}\x01\x01",
             self.user, self.access_token

--- a/examples/gmail_oauth2.rs
+++ b/examples/gmail_oauth2.rs
@@ -13,7 +13,7 @@ struct GmailOAuth2 {
 impl Authenticator for GmailOAuth2 {
     type Response = String;
     #[allow(unused_variables)]
-    fn process(&self, data: Vec<u8>) -> Self::Response {
+    fn process(&self, data: &[u8]) -> Self::Response {
         format!(
             "user={}\x01auth=Bearer {}\x01\x01",
             self.user, self.access_token

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1,4 +1,5 @@
 /// This will allow plugable authentication mechanisms.
 pub trait Authenticator {
-    fn process(&self, String) -> String;
+    type Response: AsRef<[u8]>;
+    fn process(&self, String) -> Self::Response;
 }

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1,5 +1,5 @@
 /// This will allow plugable authentication mechanisms.
 pub trait Authenticator {
     type Response: AsRef<[u8]>;
-    fn process(&self, String) -> Self::Response;
+    fn process(&self, Vec<u8>) -> Self::Response;
 }

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1,5 +1,16 @@
 /// This will allow plugable authentication mechanisms.
+///
+/// This trait is used by `Client::authenticate` to [authenticate
+/// using SASL](https://tools.ietf.org/html/rfc3501#section-6.2.2).
 pub trait Authenticator {
+    /// Type of the response to the challenge. This will usually be a
+    /// `Vec<u8>` or `String`. It must not be Base64 encoded: the
+    /// library will do it.
     type Response: AsRef<[u8]>;
+    /// For each server challenge is passed to `process`. The library
+    /// has already decoded the Base64 string into bytes.
+    ///
+    /// The `process` function should return its response, not Base64
+    /// encoded: the library will do it.
     fn process(&self, &[u8]) -> Self::Response;
 }

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1,5 +1,5 @@
 /// This will allow plugable authentication mechanisms.
 pub trait Authenticator {
     type Response: AsRef<[u8]>;
-    fn process(&self, Vec<u8>) -> Self::Response;
+    fn process(&self, &[u8]) -> Self::Response;
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -395,8 +395,8 @@ impl<T: Read + Write> Client<T> {
                     parse_authenticate_response(String::from_utf8(line).unwrap()),
                     self
                 );
-                let auth_response = base64::encode(authenticator.process(data).as_str());
-
+                let raw_response = &authenticator.process(data);
+                let auth_response = base64::encode(raw_response);
                 ok_or_unauth_client_err!(
                     self.write_line(auth_response.into_bytes().as_slice()),
                     self
@@ -948,8 +948,9 @@ mod tests {
         let client = Client::new(mock_stream);
         enum Authenticate { Auth };
         impl Authenticator for Authenticate {
-            fn process(&self, _: String) -> String {
-                "foo".to_string()
+            type Response = Vec<u8>;
+            fn process(&self, _: String) -> Self::Response {
+                b"foo".to_vec()
             }
         }
         let auth = Authenticate::Auth;

--- a/src/client.rs
+++ b/src/client.rs
@@ -402,7 +402,7 @@ impl<T: Read + Write> Client<T> {
                         ),
                     self
                 );
-                let raw_response = &authenticator.process(challenge);
+                let raw_response = &authenticator.process(&challenge);
                 let auth_response = base64::encode(raw_response);
                 ok_or_unauth_client_err!(
                     self.write_line(auth_response.into_bytes().as_slice()),
@@ -956,9 +956,9 @@ mod tests {
         enum Authenticate { Auth };
         impl Authenticator for Authenticate {
             type Response = Vec<u8>;
-            fn process(&self, challenge: Vec<u8>) -> Self::Response {
+            fn process(&self, challenge: &[u8]) -> Self::Response {
                 assert!(
-                    challenge == b"bar".to_vec(),
+                    challenge == b"bar",
                     "Invalid authenticate challenge"
                 );
                 b"foo".to_vec()

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,7 +7,7 @@ use super::error::{Error, ParseError, Result};
 use super::types::*;
 
 pub fn parse_authenticate_response(line: String) -> Result<String> {
-    let authenticate_regex = Regex::new("^+(.*)\r\n").unwrap();
+    let authenticate_regex = Regex::new("^\\+(.*)\r\n").unwrap();
 
     if let Some(cap) = authenticate_regex.captures_iter(line.as_str()).next() {
         let data = cap.get(1).map(|x| x.as_str()).unwrap_or("");


### PR DESCRIPTION
Fixes issue #95.

Please bear with me, I'm only beginning Rust.

I see two issues with this one-liner:

1. it is _not_ backward compatible. What's the rules for this?
2. as `Authenticator::process` returns a `String`, it is not possible to submit arbitrary binary data. For fixing this `process` would have to return a `Vec<u8>`. What do you think?
