### PR TITLE
[BUGFIX] Expect a space after the "+" in Client::authenticate.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -390,7 +390,7 @@ impl<T: Read + Write> Client<T> {
             // early (see also comment on `login`)
             ok_or_unauth_client_err!(self.readline(&mut line), self);
 
-            if line.starts_with(b"+") {
+            if line.starts_with(b"+ ") {
                 let data = ok_or_unauth_client_err!(
                     parse_authenticate_response(String::from_utf8(line).unwrap()),
                     self
@@ -947,7 +947,7 @@ mod tests {
 
     #[test]
     fn authenticate() {
-        let response = b"+YmFy\r\n\
+        let response = b"+ YmFy\r\n\
                          a1 OK Logged in\r\n".to_vec();
         let command =  "a1 AUTHENTICATE PLAIN\r\n\
                         Zm9v\r\n";

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,7 +7,7 @@ use super::error::{Error, ParseError, Result};
 use super::types::*;
 
 pub fn parse_authenticate_response(line: String) -> Result<String> {
-    let authenticate_regex = Regex::new("^\\+(.*)\r\n").unwrap();
+    let authenticate_regex = Regex::new("^\\+ (.*)\r\n").unwrap();
 
     if let Some(cap) = authenticate_regex.captures_iter(line.as_str()).next() {
         let data = cap.get(1).map(|x| x.as_str()).unwrap_or("");


### PR DESCRIPTION
RFC 3501: A continue-req from the server starts with "+" SP.